### PR TITLE
Small updates to rust-htslib

### DIFF
--- a/rust-htslib/Cargo.toml
+++ b/rust-htslib/Cargo.toml
@@ -6,4 +6,5 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-rust-htslib = { version = "*", path="/home/brentp/src/rust-htslib/" }
+#rust-htslib = { version = "*", path="/home/brentp/src/rust-htslib/" }
+rust-htslib = { version = "*", features = ["libdeflate"] }

--- a/rust-htslib/src/main.rs
+++ b/rust-htslib/src/main.rs
@@ -1,30 +1,24 @@
 extern crate rust_htslib;
-use crate::rust_htslib::bcf::{Reader, Read};
+use crate::rust_htslib::bcf::{Read, Reader};
 use std::io::Write;
-
 
 fn main() {
     let args: Vec<String> = std::env::args().collect();
     let path = &*args[1];
     let mut bcf = Reader::from_path(path).expect("couldn't open input vcf");
 
-    let mut li: Vec<i64> = Vec::new();
+    let mut li: Vec<i32> = Vec::new();
 
     for r in bcf.records() {
         let rec = r.expect("error getting record");
 
-         match rec.info(b"AN").integer().expect("error acessing info") {
-                 Some(v) => li.push(v[0] as i64),
-                 None => continue,
-         }
-
+        if let Some(v) = rec.info(b"AN").integer().expect("error acessing info") {
+            li.push(v[0]);
+        }
     }
     let mut stderr = std::io::stderr();
-    let s:i64 = li.iter().sum();
+    let s: i32 = li.iter().sum();
 
-     writeln!(stderr, "sum: {}, avg:{}", s, s / li.len() as i64).expect("error writing to stderr");
-
-
-
-    
+    writeln!(stderr, "sum: {}, avg:{}", s, s as f64 / li.len() as f64)
+        .expect("error writing to stderr");
 }


### PR DESCRIPTION
This switches rust-htslib to using libdeflate and also tweaks a few small things like the i32 size to match the zig impl. 