### PR TITLE
Read compressed bcf in noodles

### DIFF
--- a/rust-noodles/Cargo.toml
+++ b/rust-noodles/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-noodles-vcf = { git = "https://github.com/zaeleus/noodles", rev = "3a17554" }
-noodles-bcf = { git = "https://github.com/zaeleus/noodles", rev = "3a17554" }
+noodles-vcf = { git = "https://github.com/zaeleus/noodles", rev = "333b312" }
+noodles-bcf = { git = "https://github.com/zaeleus/noodles", rev = "333b312" }

--- a/rust-noodles/src/main.rs
+++ b/rust-noodles/src/main.rs
@@ -30,7 +30,7 @@ fn main() -> io::Result<()> {
 
     let mut bcf = fs::File::open(path)
         .map(io::BufReader::new)
-        .map(bcf::Reader::from)?;
+        .map(bcf::Reader::new)?;
     bcf.read_file_format()?;
 
     let raw_header = bcf.read_header()?;


### PR DESCRIPTION
Read compressed rather than uncompressed BCF in noodles.

Sorry for the confusion.