### PR TITLE
Update to noodles 0.14.0

### DIFF
--- a/rust-noodles/Cargo.toml
+++ b/rust-noodles/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 noodles = { version = "0.14.0", features = ["bcf", "vcf"] }
+noodles-bgzf = { version = "0.7.0", features = ["libdeflate"] }

--- a/rust-noodles/Cargo.toml
+++ b/rust-noodles/Cargo.toml
@@ -4,5 +4,4 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-noodles-vcf = { git = "https://github.com/zaeleus/noodles", rev = "333b312" }
-noodles-bcf = { git = "https://github.com/zaeleus/noodles", rev = "333b312" }
+noodles = { version = "0.14.0", features = ["bcf", "vcf"] }

--- a/rust-noodles/src/main.rs
+++ b/rust-noodles/src/main.rs
@@ -29,16 +29,16 @@ fn get_allele_count(
 fn main() -> io::Result<()> {
     let path = env::args().nth(1).expect("missing BCF path");
 
-    let mut bcf = fs::File::open(path)
+    let mut reader = fs::File::open(path)
         .map(io::BufReader::new)
         .map(bcf::Reader::new)?;
-    bcf.read_file_format()?;
+    reader.read_file_format()?;
 
-    let raw_header = bcf.read_header()?;
+    let raw_header = reader.read_header()?;
     let header = raw_header.parse().expect("error parsing header");
     let string_map = raw_header.parse().expect("error parsing header");
 
-    let allele_counts = bcf
+    let allele_counts = reader
         .records()
         .map(|record| get_allele_count(record, &header, &string_map))
         .collect::<io::Result<Option<Vec<i32>>>>()?

--- a/rust-noodles/src/main.rs
+++ b/rust-noodles/src/main.rs
@@ -3,11 +3,12 @@ use std::{
     io::{self, Write},
 };
 
-use noodles_bcf as bcf;
-
-use noodles_vcf::{
-    self as vcf,
-    record::info::field::{Key, Value},
+use noodles::{
+    bcf,
+    vcf::{
+        self,
+        record::info::field::{Key, Value},
+    },
 };
 
 fn get_allele_count(


### PR DESCRIPTION
I updated to noodles 0.14.0, enabled libdeflate, and reused a buffer when reading records.

To re-evaluate with the default inflater (i.e., miniz_oxide), libdeflate can be disabled by removing the `libdeflate` feature from the `noodles-bgzf` dependency in the project manifest.