### PR TITLE
D benchmark using dhtslib

### DIFF
--- a/d-dhtslib/.gitignore
+++ b/d-dhtslib/.gitignore
@@ -1,0 +1,15 @@
+.dub
+docs.json
+__dummy.html
+docs/
+/read
+read.so
+read.dylib
+read.dll
+read.a
+read.lib
+read-test-*
+*.exe
+*.o
+*.obj
+*.lst

--- a/d-dhtslib/dub.json
+++ b/d-dhtslib/dub.json
@@ -1,0 +1,12 @@
+{
+	"authors": [
+		"Charles Gregory"
+	],
+	"copyright": "Copyright © 2022, Charles Gregory",
+	"dependencies": {
+		"dhtslib": "~>0.13.3"
+	},
+	"description": "evaluating vcf parsing with dhtslib",
+	"license": "MIT",
+	"name": "read"
+}

--- a/d-dhtslib/source/app.d
+++ b/d-dhtslib/source/app.d
@@ -1,0 +1,23 @@
+import std.stdio;
+import std.algorithm : sum;
+import dhtslib;
+
+/// Ported from rust-htslib implementation
+
+void main(string[] args)
+{
+	// open vcf reader
+	auto vcfr = VCFReader(args[1]);
+	long[] li;
+
+	// loop over records and get the AN INFO field
+	// and append it to our list
+	foreach(rec; vcfr)
+	{
+		li ~= rec.getInfos["AN"].to!int;
+	}
+
+	// sum and print
+	auto s = li.sum;
+	stderr.writefln("sum: %d, avg: %f", s, double(s) / double(li.length));
+}


### PR DESCRIPTION
I have added a D implementation using the htslib bindings/wrapper library, [dhtslib](https://github.com/blachlylab/dhtslib).

I tried to replicate the rust implementation that uses rust-htslib. In D, we could use `map` with ranges to avoid the array allocation and potentially add some extra performance. Though I think rust could do this as well. `dhtslib` will link to the default system `htslib` library so it can also take advantage of `libdeflate`. 

In my testing from my laptop, `dhtslib` performance should be on par with c-htslib, rust-htslib, and nim. My timings were longer on the laptop for the tests so I didn't update the README. 

Building the D binary requires having a D compiler (we use ldc for best performance) and `dub`. 
My preferred way of installing these is:
```bash
curl -fsS https://dlang.org/install.sh | bash -s ldc
```
And then sourcing the install environment:
```bash
source ~/dlang/ldc-1.28.0/activate
```
The binary can be built using:
```
cd d-dhtslib
# LIBRARY_PATH is set to htslib install location
# this is needed as ldc uses ld.gold by default
LIBRARY_PATH=/usr/local/lib dub build -b release
```

Run using:
```
time d-dhtslib/read 1kg.chr1.subset.bcf
```